### PR TITLE
Support string exif version

### DIFF
--- a/lib/exexif/decode.ex
+++ b/lib/exexif/decode.ex
@@ -292,7 +292,7 @@ defmodule Exexif.Decode do
   defp flash(0x5F), do: "Auto, Fired, Red-eye reduction, Return detected"
   defp flash(other), do: "Unknown (#{other})"
 
-  @spec version(charlist() | String.t()) :: binary()
+  @spec version(charlist() | binary()) :: binary()
   defp version([?0, major, minor1, minor2]) do
     <<major, ?., minor1, minor2>>
   end

--- a/lib/exexif/decode.ex
+++ b/lib/exexif/decode.ex
@@ -152,11 +152,13 @@ defmodule Exexif.Decode do
   @comp_conf {"-", "Y", "Cb", "Cr", "R", "G", "B"}
 
   @spec component_configuration([non_neg_integer()]) :: binary()
-  defp component_configuration(list) do
+  defp component_configuration(list) when is_list(list) do
     list
     |> Enum.map(&elem(@comp_conf, &1))
     |> Enum.join(",")
   end
+
+  defp component_configuration(_), do: nil
 
   @spec metering_mode(non_neg_integer()) :: binary()
   defp metering_mode(1), do: "Average"

--- a/lib/exexif/decode.ex
+++ b/lib/exexif/decode.ex
@@ -290,12 +290,20 @@ defmodule Exexif.Decode do
   defp flash(0x5F), do: "Auto, Fired, Red-eye reduction, Return detected"
   defp flash(other), do: "Unknown (#{other})"
 
-  @spec version(charlist()) :: binary()
+  @spec version(charlist() | String.t()) :: binary()
   defp version([?0, major, minor1, minor2]) do
     <<major, ?., minor1, minor2>>
   end
 
   defp version([major1, major2, minor1, minor2]) do
+    <<major1, major2, ?., minor1, minor2>>
+  end
+
+  defp version(<<?0, major, minor1, minor2>>) do
+    <<major, ?., minor1, minor2>>
+  end
+
+  defp version(<<major1, major2, minor1, minor2>>) do
     <<major1, major2, ?., minor1, minor2>>
   end
 end


### PR DESCRIPTION
I've found an image with the version set as `"0220"` instead of `'0220'`.

I cannot add the image since it has some Personal Identifiable Information (PII), and modifying the image with GIMP returned an integer value for the version (`220`, weird), so I didn't added any tests.

This should fix the exception:

```
** (FunctionClauseError) no function clause matching in Exexif.Decode.version/1

    The following arguments were given to Exexif.Decode.version/1:

        # 1
        "0220"

    Attempted function clauses (showing 2 out of 2):

        defp version([48, major, minor1, minor2])
        defp version([major1, major2, minor1, minor2])

    (nextexif 0.1.1) lib/exexif/decode.ex:294: Exexif.Decode.version/1
    (nextexif 0.1.1) lib/exexif/decode.ex:39: Exexif.Decode.tag/3
    (nextexif 0.1.1) lib/exexif.ex:175: Exexif.read_tags/5
    (nextexif 0.1.1) lib/exexif.ex:179: Exexif.read_tags/5
    (nextexif 0.1.1) lib/exexif.ex:127: Exexif.read_exif/1
```