### PR TITLE
Fix unhandled EXIF version parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /doc
 erl_crash.dump
 *.ez
+**/.DS_Store

--- a/lib/exexif/decode.ex
+++ b/lib/exexif/decode.ex
@@ -292,20 +292,40 @@ defmodule Exexif.Decode do
   defp flash(0x5F), do: "Auto, Fired, Red-eye reduction, Return detected"
   defp flash(other), do: "Unknown (#{other})"
 
-  @spec version(charlist() | binary()) :: binary()
-  defp version([?0, major, minor1, minor2]) do
+  @spec version(charlist() | binary() | non_neg_integer()) :: binary()
+  def version([?0, major, minor1, minor2]) do
     <<major, ?., minor1, minor2>>
   end
 
-  defp version([major1, major2, minor1, minor2]) do
+  def version([major1, major2, minor1, minor2]) do
     <<major1, major2, ?., minor1, minor2>>
   end
 
-  defp version(<<?0, major, minor1, minor2>>) do
+  def version(<<?0, major, minor1, minor2>>) do
     <<major, ?., minor1, minor2>>
   end
 
-  defp version(<<major1, major2, minor1, minor2>>) do
+  def version(<<major1, major2, minor1, minor2>>) do
     <<major1, major2, ?., minor1, minor2>>
+  end
+
+  def version(<<?0, major2, minor1>>) do
+    <<major2, ?., minor1, ?0>>
+  end
+
+  def version(<<major1, major2, minor1>>) do
+    <<major1, major2, ?., minor1, ?0>>
+  end
+
+  def version([?0, major2, minor1]) do
+    <<major2, ?., minor1, ?0>>
+  end
+
+  def version([major1, major2, minor1]) do
+    <<major1, major2, ?., minor1, ?0>>
+  end
+
+  def version(version) when is_integer(version) and version >= 100 and version <= 999 do
+    version("0#{Integer.to_string(version)}")
   end
 end

--- a/test/exif/decode_test.exs
+++ b/test/exif/decode_test.exs
@@ -1,0 +1,34 @@
+defmodule Exexif.DecodeTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+  @subject Exexif.Decode
+
+  describe "version" do
+    test "Long version (4 digits) in binary" do
+      assert @subject.version("0220") == "2.20"
+      assert @subject.version("0221") == "2.21"
+      assert @subject.version("1221") == "12.21"
+    end
+
+    test "Long version (4 digits) in charlist" do
+      assert @subject.version('0220') == "2.20"
+      assert @subject.version('0221') == "2.21"
+      assert @subject.version('1221') == "12.21"
+    end
+
+    test "Short version (3 digits) in binary" do
+      assert @subject.version("022") == "2.20"
+      assert @subject.version("122") == "12.20"
+    end
+
+    test "Short version (3 digits) in charlist" do
+      assert @subject.version('022') == "2.20"
+      assert @subject.version('122') == "12.20"
+    end
+
+    test "Integer Version - GIMP modified image" do
+      assert @subject.version(220) == "2.20"
+      assert @subject.version(221) == "2.21"
+    end
+  end
+end


### PR DESCRIPTION
Notice that some Xiaomi camera photos only use 3 3-digit EXIF version. Also, a modified GIMP image saved with EXIF metadata changes the EXIF version to an integer.